### PR TITLE
Update to Rust 2018

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,6 @@
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
-  #"--emit=asm",
-]
+runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+rustflags = ["-C", "link-arg=-Tlink.x"]
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,24 @@ name = "stm32f767-hal"
 repository = "https://github.com/therealprof/stm32f767-hal"
 documentation = "https://docs.rs/stm32f767-hal"
 readme = "README.md"
+edition = "2018"
 version = "0.3.0-dev"
 
 [dependencies]
-cortex-m = "0.5.2"
-cortex-m-rt = "0.5.1"
+cortex-m-rt = "0.6.7"
 nb = "0.1.1"
-panic-abort = "0.2.0"
 
-[dependencies.bare-metal]
-version = "0.2.0"
+[dependencies.cortex-m]
 features = ["const-fn"]
+version = "0.5.8"
+
+[dependencies.stm32f7]
+features = ["stm32f7x7"]
+version = "0.6.0"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false
@@ -26,27 +33,20 @@ version = "0.2.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.1"
-
-[dependencies.stm32f7]
-features = [
-    "stm32f7x7",
-    "rt",
-]
-version = "0.2.0"
+version = "0.2.2"
 
 [dev-dependencies]
-ina260 = "0.2.1"
-numtoa = "0.0.7"
+panic-halt = "0.2.0"
 
 [features]
-default = ["rt"]
-rt = []
+rt = ["stm32f7/rt"]
+
 [profile.dev]
-debug = true
-lto = true
+incremental = false
+codegen-units = 1
 
 [profile.release]
+codegen-units = 1
 debug = true
 lto = true
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,14 @@
 [package]
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
-categories = [
-    "embedded",
-    "hardware-support",
-    "no-std",
-]
-description = "Peripheral access API for STM32F767 microcontrollers"
-documentation = "https://docs.rs/stm32f767-hal"
-keywords = [
-    "arm",
-    "cortex-m",
-    "stm32f767",
-    "hal",
-]
+categories = ["embedded", "hardware-support", "no-std"]
+description = "HAL for the STM32F767 microcontrollers"
+keywords = ["arm", "cortex-m", "stm32", "stm32f767", "hal"]
 license = "0BSD"
 name = "stm32f767-hal"
 repository = "https://github.com/therealprof/stm32f767-hal"
-version = "0.2.0"
+documentation = "https://docs.rs/stm32f767-hal"
+readme = "README.md"
+version = "0.3.0-dev"
 
 [dependencies]
 cortex-m = "0.5.2"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,48 +1,33 @@
-#![feature(used)]
-#![no_main]
+#![deny(unsafe_code)]
+#![deny(warnings)]
 #![no_std]
+#![no_main]
 
-#[macro_use(entry, exception)]
-extern crate cortex_m_rt;
+extern crate panic_halt;
 
-use cortex_m_rt::ExceptionFrame;
+use cortex_m_rt::entry;
+use stm32f767_hal::{pac, prelude::*};
 
-extern crate panic_abort;
-
-extern crate stm32f767_hal as hal;
-use hal::prelude::*;
-use hal::stm32f767;
-
-exception!(*, default_handler);
-
-fn default_handler(_irqn: i16) {}
-
-exception!(HardFault, hard_fault);
-
-fn hard_fault(_ef: &ExceptionFrame) -> ! {
-    loop {}
-}
-
-entry!(main);
-
+#[entry]
 fn main() -> ! {
-    if let Some(p) = stm32f767::Peripherals::take() {
-        let gpiob = p.GPIOB.split();
+    let p = pac::Peripherals::take().unwrap();
 
-        // Configure PB7 as output
-        let mut led = gpiob.pb7.into_push_pull_output();
+    // Acquire the GBIOB peripheral. This also enables the clock for GPIOB in
+    // the RCC register.
+    let gpiob = p.GPIOB.split();
 
-        loop {
-            // Turn PB7 on a million times in a row
-            for _ in 0..1_000_000 {
-                led.set_high();
-            }
-            // Then turn PB7 off a million times in a row
-            for _ in 0..1_000_000 {
-                led.set_low();
-            }
+    // Configure PB7 as output.
+    let mut led = gpiob.pb7.into_push_pull_output();
+
+    loop {
+        // Turn PB7 on a million times in a row.
+        for _ in 0..1_000_000 {
+            led.set_high();
+        }
+
+        // Then turn PB7 off a million times in a row.
+        for _ in 0..1_000_000 {
+            led.set_low();
         }
     }
-
-    loop {}
 }

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -1,0 +1,23 @@
+target extended-remote :3333
+
+# Print demangled symbols.
+set print asm-demangle on
+
+# Set backtrace limit to not have infinite backtrace loops.
+set backtrace limit 32
+
+# Detect unhandled exceptions, hard faults and panics.
+break DefaultHandler
+break HardFault
+break rust_begin_unwind
+
+# *Try* to stop at the user entry point (it might be gone due to inlining).
+break main
+
+# Enable semi-hosting.
+monitor arm semihosting enable
+
+load
+
+# Start the process but immediately halt the processor.
+stepi

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,11 +1,11 @@
-//! Delays
+//! # Delays
 
 use cast::u32;
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
-use hal::blocking::delay::{DelayMs, DelayUs};
-use rcc::Clocks;
+use crate::hal::blocking::delay::{DelayMs, DelayUs};
+use crate::rcc::Clocks;
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,4 +1,4 @@
-//! General Purpose Input / Output
+//! # General Purpose Input / Output
 
 use core::marker::PhantomData;
 
@@ -28,6 +28,7 @@ pub struct AF13;
 pub struct AF14;
 pub struct AF15;
 
+/// Alternate function
 pub struct Alternate<MODE> {
     _mode: PhantomData<MODE>,
 }
@@ -65,10 +66,10 @@ macro_rules! gpio {
         pub mod $gpiox {
             use core::marker::PhantomData;
 
-            use hal::digital::{InputPin, OutputPin};
-            use stm32f7::stm32f7x7::$GPIOX;
+            use crate::hal::digital::{InputPin, OutputPin};
+            use crate::pac::$GPIOX;
 
-            use stm32f7::stm32f7x7::RCC;
+            use crate::pac::RCC;
             use super::{
                 Alternate, Floating, GpioExt, Input, OpenDrain, Output,
                 PullDown, PullUp, PushPull, AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10,
@@ -529,7 +530,7 @@ gpio!(GPIOC, gpioc, gpiocen, PC, [
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
-gpio!(GPIOD, gpiod, gpioden, pd, [
+gpio!(GPIOD, gpiod, gpioden, PD, [
     PD0: (pd0, 0, Input<Floating>),
     PD1: (pd1, 1, Input<Floating>),
     PD2: (pd2, 2, Input<Floating>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,11 @@
 #![no_std]
-#![cfg_attr(feature = "rt", feature(global_asm))]
-#![cfg_attr(feature = "rt", feature(use_extern_macros))]
-#![cfg_attr(feature = "rt", feature(used))]
-#![feature(const_fn)]
-#![allow(non_camel_case_types)]
-#![feature(never_type)]
 
-extern crate bare_metal;
-extern crate cast;
-extern crate cortex_m;
-pub extern crate embedded_hal as hal;
-#[macro_use]
-pub extern crate nb;
-pub use nb::block;
-pub extern crate stm32f7;
+use embedded_hal as hal;
 
-pub use stm32f7::stm32f7x7 as stm32f767;
+pub use stm32f7::stm32f7x7 as pac;
+
+pub use crate::pac as device;
+pub use crate::pac as stm32;
 
 pub mod delay;
 pub mod gpio;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
-pub use hal::prelude::*;
+pub use crate::hal::prelude::*;
 
-pub use gpio::GpioExt as _stm32f042_hal_gpio_GpioExt;
-pub use rcc::RccExt as _stm32f042_hal_rcc_RccExt;
-pub use time::U32Ext as _stm32f042_hal_time_U32Ext;
+pub use crate::gpio::GpioExt as _stm32f767_hal_gpio_GpioExt;
+pub use crate::rcc::RccExt as _stm32f767_hal_rcc_RccExt;
+pub use crate::time::U32Ext as _stm32f767_hal_time_U32Ext;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,6 +1,8 @@
-use stm32f7::stm32f7x7::{FLASH, RCC};
+//! # Reset & Control Clock
 
-use time::Hertz;
+use crate::pac::{FLASH, RCC};
+
+use crate::time::Hertz;
 
 /// Extension trait that constrains the `RCC` peripheral
 pub trait RccExt {
@@ -184,27 +186,25 @@ impl CFGR {
             let pclk2 = hclk / ppre2;
 
             // Adjust flash wait states
-            unsafe {
-                flash.acr.write(|w| {
-                    w.latency().bits(if sysclk <= 30_000_000 {
-                        0b0000
-                    } else if sysclk <= 60_000_000 {
-                        0b0001
-                    } else if sysclk <= 90_000_000 {
-                        0b0010
-                    } else if sysclk <= 120_000_000 {
-                        0b0011
-                    } else if sysclk <= 150_000_000 {
-                        0b0100
-                    } else if sysclk <= 180_000_000 {
-                        0b0101
-                    } else if sysclk <= 210_000_000 {
-                        0b0110
-                    } else {
-                        0b0111
-                    })
+            flash.acr.write(|w| {
+                w.latency().bits(if sysclk <= 30_000_000 {
+                    0b0000
+                } else if sysclk <= 60_000_000 {
+                    0b0001
+                } else if sysclk <= 90_000_000 {
+                    0b0010
+                } else if sysclk <= 120_000_000 {
+                    0b0011
+                } else if sysclk <= 150_000_000 {
+                    0b0100
+                } else if sysclk <= 180_000_000 {
+                    0b0101
+                } else if sysclk <= 210_000_000 {
+                    0b0110
+                } else {
+                    0b0111
                 })
-            }
+            });
 
             // use PLL as source
             rcc.pllcfgr.write(|w| unsafe {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,5 @@
+//! Time units
+
 /// Bits per second
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
 pub struct Bps(pub u32);


### PR DESCRIPTION
I’ve recently purchased a Nucleo-F767ZI to get my hands on Rust Embedded, so updating this crate was a good second step after getting started with the `stm32f7` Peripheral Access Crate.

## Things done

* Bump the version to `0.3.0-dev`
* Update the description to follow the ones of other HAL implemtation crates
* Update the dependencies (and remove the unused ones)
* Update the HAL implementation to Rust 2018
    * Mandatory corrections
    * Use `pac` to refer to the Peripheral Access Crate, like in `stm32f1xx-hal`
    * Fix Clippy warnings
* Update the examples to the current idioms (and use `panic_halt` instead of `panic_abort`)
    * Change the USART to `USART2` so it is easy to use on the Nucleo board

## Things not done

Update the crate to the last idioms in term of API (like taking the RCC register to split a port, …). I may do something on this subject as a next iteration if you are OK. This won’t be my priority though, as I’ll first put my efforts on a project using an STM32L0 to demonstrate Rust to my colleagues.