### PR TITLE
Add timers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ version = "0.2.2"
 
 [dev-dependencies]
 panic-halt = "0.2.0"
+cortex-m-rtfm = "0.4.2"
 
 [features]
 rt = ["stm32f7/rt"]
@@ -50,3 +51,7 @@ codegen-units = 1
 debug = true
 lto = true
 opt-level = "s"
+
+[[example]]
+name = "timer_interrupt_rtfm"
+required-features = ["rt"]

--- a/examples/timer_interrupt_rtfm.rs
+++ b/examples/timer_interrupt_rtfm.rs
@@ -1,0 +1,61 @@
+#![deny(unsafe_code)]
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use rtfm::app;
+use stm32f767_hal::{
+    gpio::*,
+    pac,
+    prelude::*,
+    timer::{Event, Timer},
+};
+
+#[app(device = stm32f767_hal::pac)]
+const APP: () = {
+    static mut LED: gpiob::PB0<Output<PushPull>> = ();
+    static mut TIMER: Timer<pac::TIM2> = ();
+
+    #[init]
+    fn init() -> init::LateResources {
+        // Take & convert the RCC peripheral to its HAL struct.
+        let rcc = device.RCC.constrain();
+
+        // Configure the clock.
+        let clocks = rcc.cfgr.sysclk(216.mhz()).freeze();
+
+        // Acquire the GBIOB peripheral. This also enables the clock for GPIOB
+        // in the RCC register.
+        let gpiob = device.GPIOB.split();
+
+        // Configure PB0 as output.
+        let led = gpiob.pb0.into_push_pull_output();
+
+        // Configure the timer.
+        let mut timer = Timer::tim2(device.TIM2, 1.hz(), clocks);
+        timer.listen(Event::TimeOut);
+
+        // Return the initialised resources.
+        init::LateResources {
+            LED: led,
+            TIMER: timer,
+        }
+    }
+
+    #[interrupt(resources = [LED, TIMER])]
+    fn TIM2() {
+        static mut STATE: bool = false;
+
+        // Clear the interrupt flag.
+        resources.TIMER.clear_update_interrupt_flag();
+
+        if *STATE {
+            resources.LED.set_low();
+            *STATE = false;
+        } else {
+            resources.LED.set_high();
+            *STATE = true;
+        }
+    }
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod prelude;
 pub mod rcc;
 pub mod serial;
 pub mod time;
+pub mod timer;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -90,6 +90,8 @@ impl CFGR {
                 hclk: Hertz(hclk),
                 pclk1: Hertz(hclk),
                 pclk2: Hertz(hclk),
+                ppre1: 1,
+                ppre2: 1,
                 sysclk: Hertz(sysclk),
             }
         } else if sysclk == HSI && hclk < sysclk {
@@ -122,6 +124,8 @@ impl CFGR {
                 hclk: Hertz(hclk),
                 pclk1: Hertz(hclk),
                 pclk2: Hertz(hclk),
+                ppre1: 1,
+                ppre2: 1,
                 sysclk: Hertz(sysclk),
             }
         } else {
@@ -182,8 +186,8 @@ impl CFGR {
             let ppre2 = 1 << (ppre2_bits - 0b011);
 
             // Calculate new bus clocks
-            let pclk1 = hclk / ppre1;
-            let pclk2 = hclk / ppre2;
+            let pclk1 = hclk / u32::from(ppre1);
+            let pclk2 = hclk / u32::from(ppre2);
 
             // Adjust flash wait states
             flash.acr.write(|w| {
@@ -238,6 +242,8 @@ impl CFGR {
                 hclk: Hertz(hclk),
                 pclk1: Hertz(pclk1),
                 pclk2: Hertz(pclk2),
+                ppre1,
+                ppre2,
                 sysclk: Hertz(sysclk),
             }
         }
@@ -252,6 +258,8 @@ pub struct Clocks {
     hclk: Hertz,
     pclk1: Hertz,
     pclk2: Hertz,
+    ppre1: u8,
+    ppre2: u8,
     sysclk: Hertz,
 }
 
@@ -269,6 +277,16 @@ impl Clocks {
     /// Returns the frequency of the APB2
     pub fn pclk2(&self) -> Hertz {
         self.pclk2
+    }
+
+    /// Returns the prescaler of the APB1
+    pub fn ppre1(&self) -> u8 {
+        self.ppre1
+    }
+
+    /// Returns the prescaler of the APB2
+    pub fn ppre2(&self) -> u8 {
+        self.ppre2
     }
 
     /// Returns the system (core) frequency

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,204 @@
+//! Timers
+
+use embedded_hal::timer::{CountDown, Periodic};
+
+use cortex_m::peripheral::syst::SystClkSource;
+use cortex_m::peripheral::SYST;
+
+use cast::{u16, u32};
+use void::Void;
+
+use crate::pac::RCC;
+use crate::rcc::Clocks;
+use crate::time::Hertz;
+
+use crate::pac::{
+    TIM1, TIM10, TIM11, TIM12, TIM13, TIM14, TIM2, TIM3, TIM4, TIM5, TIM6, TIM7, TIM8, TIM9,
+};
+
+/// Hardware timers
+pub struct Timer<TIM> {
+    clocks: Clocks,
+    tim: TIM,
+}
+
+/// Interrupt events
+pub enum Event {
+    /// Timer timed out / count down ended
+    TimeOut,
+}
+
+impl Timer<SYST> {
+    /// Configures the SYST clock as a periodic count down timer
+    pub fn syst<T>(mut syst: SYST, timeout: T, clocks: Clocks) -> Self
+    where
+        T: Into<Hertz>,
+    {
+        syst.set_clock_source(SystClkSource::Core);
+        let mut timer = Timer { tim: syst, clocks };
+        timer.start(timeout);
+        timer
+    }
+
+    /// Starts listening for an `event`
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => self.tim.enable_interrupt(),
+        }
+    }
+
+    /// Stops listening for an `event`
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::TimeOut => self.tim.disable_interrupt(),
+        }
+    }
+}
+
+impl CountDown for Timer<SYST> {
+    type Time = Hertz;
+
+    fn start<T>(&mut self, timeout: T)
+    where
+        T: Into<Hertz>,
+    {
+        let rvr = self.clocks.sysclk().0 / timeout.into().0 - 1;
+
+        assert!(rvr < (1 << 24));
+
+        self.tim.set_reload(rvr);
+        self.tim.clear_current();
+        self.tim.enable_counter();
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Void> {
+        if self.tim.has_wrapped() {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl Periodic for Timer<SYST> {}
+
+macro_rules! hal {
+    ($($TIM:ident: ($tim:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident, $pclk:ident, $ppre:ident),)+) => {
+        $(
+            impl Timer<$TIM> {
+                /// Configures a TIM peripheral as a periodic count down timer
+                pub fn $tim<T>(tim: $TIM, timeout: T, clocks: Clocks) -> Self
+                where
+                    T: Into<Hertz>,
+                {
+                    // Enable and reset peripheral to a clean slate state
+                    let rcc = unsafe { &(*RCC::ptr()) };
+                    rcc.$apbenr.modify(|_, w| w.$timXen().set_bit());
+                    rcc.$apbrstr.modify(|_, w| w.$timXrst().set_bit());
+                    rcc.$apbrstr.modify(|_, w| w.$timXrst().clear_bit());
+
+                    let mut timer = Timer {
+                        clocks,
+                        tim,
+                    };
+
+                    timer.start(timeout);
+
+                    timer
+                }
+
+                /// Starts listening for an `event`
+                pub fn listen(&mut self, event: Event) {
+                    match event {
+                        Event::TimeOut => {
+                            // Enable update event interrupt
+                            self.tim.dier.write(|w| w.uie().set_bit());
+                        }
+                    }
+                }
+
+                /// Stops listening for an `event`
+                pub fn unlisten(&mut self, event: Event) {
+                    match event {
+                        Event::TimeOut => {
+                            // Enable update event interrupt
+                            self.tim.dier.write(|w| w.uie().clear_bit());
+                        }
+                    }
+                }
+
+                /// Stops the timer
+                pub fn stop(&mut self) {
+                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                }
+
+                /// Clears Update Interrupt Flag
+                pub fn clear_update_interrupt_flag(&mut self) {
+                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                }
+
+                /// Releases the TIM peripheral
+                pub fn release(self) -> $TIM {
+                    // pause counter
+                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                    self.tim
+                }
+            }
+
+            impl CountDown for Timer<$TIM> {
+                type Time = Hertz;
+
+                fn start<T>(&mut self, timeout: T)
+                where
+                    T: Into<Hertz>,
+                {
+                    // pause
+                    self.tim.cr1.modify(|_, w| w.cen().clear_bit());
+                    // reset counter
+                    self.tim.cnt.reset();
+
+                    let frequency = timeout.into().0;
+                    let pclk_mul = if self.clocks.$ppre() == 1 { 1 } else { 2 };
+                    let ticks = self.clocks.$pclk().0 * pclk_mul / frequency;
+
+                    let psc = u16((ticks - 1) / (1 << 16)).unwrap();
+                    self.tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+
+                    let arr = u16(ticks / u32(psc + 1)).unwrap();
+                    self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
+
+                    // start counter
+                    self.tim.cr1.modify(|_, w| w.cen().set_bit());
+                }
+
+                fn wait(&mut self) -> nb::Result<(), Void> {
+                    if self.tim.sr.read().uif().bit_is_clear() {
+                        Err(nb::Error::WouldBlock)
+                    } else {
+                        self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                        Ok(())
+                    }
+                }
+            }
+
+            impl Periodic for Timer<$TIM> {}
+        )+
+    }
+}
+
+hal! {
+    TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr, pclk2, ppre2),
+    TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM4: (tim4, tim4en, tim4rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM5: (tim5, tim5en, tim5rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM6: (tim6, tim6en, tim6rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM7: (tim7, tim7en, tim7rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM8: (tim8, tim8en, tim8rst, apb2enr, apb2rstr, pclk2, ppre2),
+    TIM9: (tim9, tim9en, tim9rst, apb2enr, apb2rstr, pclk2, ppre2),
+    TIM10: (tim10, tim10en, tim10rst, apb2enr, apb2rstr, pclk2, ppre2),
+    TIM11: (tim11, tim11en, tim11rst, apb2enr, apb2rstr, pclk2, ppre2),
+    TIM12: (tim12, tim12en, tim12rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM13: (tim13, tim13en, tim13rst, apb1enr, apb1rstr, pclk1, ppre1),
+    TIM14: (tim14, tim14en, tim14rst, apb1enr, apb1rstr, pclk1, ppre1),
+}


### PR DESCRIPTION
I’ve added an implementation for using the timers. It is mainly inspired by `stm32f4xx-hal`, with `stop` and `clear_update_interrupt_flag` being carried from `stm32f1xx-hal`.

I needed to add the prescalers in the `Clocks` struct in the RCC module.

I’ve written an example, too.